### PR TITLE
Ensure stable browser compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,22 @@ section on GitHub. Download the minified version and include it in your page:
    <button onclick="setLang('en')">English version</button>
    ```
 
+## Browser support
+
+`vavilon.js` works on [99%][browserslist] of browsers used today:
+
+| ![Chrome][chrome] | ![Safari][safari] | ![Firefox][firefox] | ![MS Edge][edge] | ![Internet Explorer][ie] | ![Opera][opera] |
+|:-----------------:|:-----------------:|:-------------------:|:----------------:|:------------------------:|:---------------:|
+|       **15+**     |       **5+**      |        **45+**      |      **12+**     |          **9+**          |    **12.1+**    |
+
+[chrome]:  https://github.com/alrra/browser-logos/raw/master/src/chrome/chrome_48x48.png
+[edge]:    https://github.com/alrra/browser-logos/raw/master/src/edge/edge_48x48.png
+[firefox]: https://github.com/alrra/browser-logos/raw/master/src/firefox/firefox_48x48.png
+[ie]:      https://github.com/alrra/browser-logos/raw/master/src/archive/internet-explorer_9-11/internet-explorer_9-11_48x48.png
+[opera]:   https://github.com/alrra/browser-logos/raw/master/src/opera/opera_48x48.png
+[safari]:  https://github.com/alrra/browser-logos/raw/master/src/safari/safari_48x48.png
+[browserslist]: https://browserslist.dev/?q=Y292ZXIgMTAwJSwgbm90IGNocm9tZSA8IDE1LCBub3QgYW5kX2NociA8IDE1LCBub3Qgc2FmYXJpIDwgNSwgbm90IGlvc19zYWYgPCA1LCBub3QgZmlyZWZveCA8IDQ1LCBub3QgYW5kX2ZmIDwgNDUsIG5vdCBlZGdlIDwgMTIsIG5vdCBpZSA8IDksIG5vdCBpZV9tb2IgPCA5LCBub3Qgb3BlcmEgPCAxMi4xLCBub3Qgb3BfbW9iIDwgMTIuMSwgbm90IG9wX21pbmkgPCAxMi4xLCBub3QgYW5kcm9pZCA8IDQuNA%3D%3D
+
 ## Caveats
 
 Despite being a stable release, `vavilon.js` is not completely finished. Here

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,23 @@
+import { Locale } from './types';
+
+// This is needed to be able to work with older IE and to be able to assign a new property to Window
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+declare global {
+  interface NavigatorLanguage {
+    readonly browserLanguage: string;
+    readonly userLanguage: string;
+  }
+
+  interface Window {
+    /**
+     * Changes the page language
+     *
+     * The execution of this method will change the {@link Vavilon.pageLocale}
+     * of the vavilon instance, save the selected locale to cookie and replace
+     * the text of all the vavilon-enabled elements on the page.
+     *
+     * @param localeString - the locale to switch to
+     */
+    setLang(localeString: Locale): void;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,26 +1,6 @@
 import { Vavilon } from './vavilon';
 import { Locale } from './types';
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-declare global {
-  interface Window {
-    // IE navigator language settings (non-standard)
-    userLanguage: string;
-    browserLanguage: string;
-
-    /**
-     * Changes the page language
-     *
-     * The execution of this method will change the {@link Vavilon.pageLocale}
-     * of the vavilon instance, save the selected locale to cookie and replace
-     * the text of all the vavilon-enabled elements on the page.
-     *
-     * @param localeString - the locale to switch to
-     */
-    setLang(localeString: Locale): void;
-  }
-}
-
 /**
  * Core vavilon object instance
  *

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -12,8 +12,8 @@ import { Locale } from './types';
 export function getUserLocale(): Locale {
   return (getLocaleCookie()
       || window.navigator.language
-      || window.browserLanguage
-      || window.userLanguage)
+      || window.navigator.browserLanguage
+      || window.navigator.userLanguage)
     .toLowerCase();
 }
 

--- a/src/vavilon.ts
+++ b/src/vavilon.ts
@@ -73,10 +73,6 @@ export class Vavilon {
    */
   public replace(): void {
     if (this.elements && this.pageDict) {
-      if (!this.dictionaries[this.pageLocale]) {
-        this.dictionaries[this.pageLocale] = new Dictionary(null);
-      }
-
       for (let i = 0; i < this.elements.length; i += 1) {
         const el = this.elements[i];
         const strId = el.getAttribute('data-vavilon');
@@ -104,6 +100,10 @@ export class Vavilon {
         this.dictionaries[dictLocale.toLowerCase()] = new Dictionary(el.src);
       }
     }
+
+    if (!this.dictionaries[this.pageLocale]) {
+      this.dictionaries[this.pageLocale] = new Dictionary(null);
+    }
   }
 
   /**
@@ -115,20 +115,19 @@ export class Vavilon {
    * @param primaryCb - an optional callback to execute after the {@link pageDict} has been loaded
    */
   public loadDicts(primaryCb?: () => void): void {
-    const locales = Object.keys(this.dictionaries);
-    for (let i = 0; i < locales.length; i += 1) {
-      const loc = locales[i];
-      if (loc === this.userLocale
+    Object.keys(this.dictionaries)
+      .forEach((loc) => {
+        if (loc === this.userLocale
           || (loc.slice(0, 2) === this.userLocale.slice(0, 2) && !this.pageDict)) {
-        this.pageDict = loc;
-        this.dictionaries[loc].load((): void => {
-          this.pageDictLoaded = true;
-          primaryCb();
-        });
-      } else {
-        this.dictionaries[loc].load();
-      }
-    }
+          this.pageDict = loc;
+          this.dictionaries[loc].load((): void => {
+            this.pageDictLoaded = true;
+            primaryCb();
+          });
+        } else {
+          this.dictionaries[loc].load();
+        }
+      });
   }
 
   /**


### PR DESCRIPTION
Surprisingly, there is no tool at the moment that would either a) provide lightweight polyfills for missing functions; or b) alert developers when they use unsupported features. https://github.com/amilajack/eslint-plugin-compat is alright, but isn't bug-free at the moment.

This PR contains lots of manual fixes to ensure great browser compatibility. The code was tested on BrowserStack to make sure that all browsers, defined by the `cover 96%` Browserslist query, support it. Basically it runs on every modern Chrome, FF, Safari and Opera version as well as IE up to version 9. Thus, this issue closes #43.